### PR TITLE
add authorization to header only if specified by user

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -127,7 +127,8 @@ def retrieve_data(args, template, query_args=None, single_request=False):
         }.items() + query_args.items()))
 
         request = urllib2.Request(template + '?' + querystring)
-        request.add_header('Authorization', 'Basic ' + auth)
+        if auth is not None:
+            request.add_header('Authorization', 'Basic ' + auth)
         r = urllib2.urlopen(request)
 
         errors = []


### PR DESCRIPTION
Otherwise `'basic ' + auth` raises a `TypeError` because in `get_auth` the default value of `auth` is `None`. Since authentication credentials are optional arguments and the help message does not mention that at least one of them is required, this appears to be the intended behavior, taking into consideration also [this warning message](https://github.com/josegonzalez/python-github-backup/blob/5b23fa6491494b53ce8d53d2ea8d0da010c2ea3f/bin/github-backup#L140). Also, since it does work w/o credentials, it is nice to provide this option for any user that doesn't want to provide a password or token.
