### PR TITLE
Add GitHub Enterprise Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ CLI Usage is as follows::
                      [-o OUTPUT_DIRECTORY] [--starred] [--watched] [--all]
                      [--issues] [--issue-comments] [--issue-events]
                      [--repositories] [--wikis] [--skip-existing]
-                     [-L [LANGUAGES [LANGUAGES ...]]] [-N NAME_REGEX] [-O]
-                     [-R REPOSITORY] [-P] [-F] [-v]
+                     [-L [LANGUAGES [LANGUAGES ...]]] [-N NAME_REGEX]
+                     [-H GITHUB_HOST] [-O] [-R REPOSITORY] [-P] [-F] [-v]
                      USER
 
     Backup a github users account
@@ -56,6 +56,8 @@ CLI Usage is as follows::
                             only allow these languages
       -N NAME_REGEX, --name-regex NAME_REGEX
                             python regex to match names against
+      -H GITHUB_HOST, --github-host GITHUB_HOST
+                            GitHub Enterprise hostname
       -O, --organization    whether or not this is a query for an organization
       -R REPOSITORY, --repository REPOSITORY
                             name of repository to limit backup to

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -93,6 +93,7 @@ def parse_args():
     parser.add_argument('--skip-existing', action='store_true', dest='skip_existing', help='skip project if a backup directory exists')
     parser.add_argument('-L', '--languages', dest='languages', help='only allow these languages', nargs='*')
     parser.add_argument('-N', '--name-regex', dest='name_regex', help='python regex to match names against')
+    parser.add_argument('-H', '--github-host', dest='github_host', help='GitHub Enterprise hostname')
     parser.add_argument('-O', '--organization', action='store_true', dest='organization', help='whether or not this is a query for an organization')
     parser.add_argument('-R', '--repository', dest='repository', help='name of repository to limit backup to')
     parser.add_argument('-P', '--private', action='store_true', dest='private', help='include private repositories')
@@ -114,6 +115,21 @@ def get_auth(args):
 
     return auth
 
+def get_github_api_host(args):
+    if args.github_host:
+        host = args.github_host + '/api/v3'
+    else:
+        host = 'api.github.com'
+
+    return host
+
+def get_github_ssh_host(args):
+    if args.github_host:
+        host = args.github_host
+    else:
+        host = 'github.com'
+
+    return host
 
 def retrieve_data(args, template, query_args=None, single_request=False):
     auth = get_auth(args)
@@ -170,13 +186,13 @@ def retrieve_data(args, template, query_args=None, single_request=False):
 def retrieve_repositories(args):
     log_info('Retrieving repositories')
     single_request = False
-    template = 'https://api.github.com/users/{0}/repos'.format(args.user)
+    template = 'https://{0}/users/{1}/repos'.format(get_github_api_host(args), args.user)
     if args.organization:
-        template = 'https://api.github.com/orgs/{0}/repos'.format(args.user)
+        template = 'https://{0}/orgs/{1}/repos'.format(get_github_api_host(args), args.user)
 
     if args.repository:
         single_request = True
-        template = 'https://api.github.com/repos/{0}/{1}'.format(args.user, args.repository)
+        template = 'https://{0}/repos/{1}/{2}'.format(get_github_api_host(args), args.user, args.repository)
 
     return retrieve_data(args, template, single_request=single_request)
 
@@ -205,8 +221,8 @@ def filter_repositories(args, repositories):
 
 def backup_repositories(args, output_directory, repositories):
     log_info('Backing up repositories')
-    issue_template = "https://api.github.com/repos"
-    wiki_template = "git@github.com:{0}.wiki.git"
+    issue_template = 'https://{0}/repos'.format(get_github_api_host(args))
+    wiki_template = "git@{0}:{1}.wiki.git"
 
     issue_states = ['open', 'closed']
     for repository in repositories:
@@ -240,7 +256,7 @@ def backup_repositories(args, output_directory, repositories):
                 logging_subprocess(git_command, logger=None, cwd=os.path.join(repo_cwd, 'wiki'))
             else:
                 log_info('Cloning {0} wiki'.format(repository['full_name']))
-                git_command = ["git", "clone", wiki_template.format(repository['full_name']), 'wiki']
+                git_command = ["git", "clone", wiki_template.format(get_github_ssh_host(args), repository['full_name']), 'wiki']
                 logging_subprocess(git_command, logger=None, cwd=repo_cwd)
 
         if args.include_issues or args.include_everything:
@@ -284,8 +300,8 @@ def backup_account(args, output_directory):
             log_info('Retrieving {0} starred repositories'.format(args.user))
             mkdir_p(account_cwd)
 
-            starred_template = "https://api.github.com/users/{0}/starred"
-            starred = retrieve_data(args, starred_template.format(args.user))
+            starred_template = "https://{0}/users/{1}/starred"
+            starred = retrieve_data(args, starred_template.format(get_github_api_host(args), args.user))
             log_info('Writing {0} starred repositories'.format(len(starred)))
             with open('{0}/starred.json'.format(account_cwd), 'w') as starred_file:
                 json.dump(starred, starred_file, sort_keys=True, indent=4, separators=(',', ': '))
@@ -295,8 +311,8 @@ def backup_account(args, output_directory):
             log_info('Retrieving {0} watched repositories'.format(args.user))
             mkdir_p(account_cwd)
 
-            watched_template = "https://api.github.com/users/{0}/subscriptions"
-            watched = retrieve_data(args, watched_template.format(args.user))
+            watched_template = "https://{0}/users/{1}/subscriptions"
+            watched = retrieve_data(args, watched_template.format(get_github_api_host(args), args.user))
             log_info('Writing {0} watched repositories'.format(len(watched)))
             with open('{0}/watched.json'.format(account_cwd), 'w') as watched_file:
                 json.dump(watched, watched_file, sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
Pass the `-H` or `--github-host` argument with a GitHub Enterprise hostname to backup from that GitHub enterprise host. If no argument is passed then back up from github.com.

I ran into this while working with this script at work. Figured it may be useful for others without access to the official GitHub Enterprise backup tools. I've tested it to work on both my GitHub installation at work and the public github.com.