### PR TITLE
Added test for uninitialized repo's (or wiki's)

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -357,6 +357,11 @@ def fetch_repository(name, remote_url, local_dir, skip_existing=False):
     if clone_exists and skip_existing:
         return
 
+    initalized = subprocess.call('git ls-remote ' + remote_url,  stdout=FNULL, stderr=FNULL, shell=True)
+	if initalized == 128:
+		log_info("Skipping {} since it's not initalized".format(name))
+		return
+    
     if clone_exists:
         log_info('Updating {} in {}'.format(name, local_dir))
         git_command = ['git', 'fetch', '--all', '--tags', '--prune']

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -359,9 +359,9 @@ def fetch_repository(name, remote_url, local_dir, skip_existing=False):
         return
 
     initalized = subprocess.call('git ls-remote ' + remote_url,  stdout=FNULL, stderr=FNULL, shell=True)
-	if initalized == 128:
-		log_info("Skipping {} since it's not initalized".format(name))
-		return
+    if initalized == 128:
+        log_info("Skipping {} since it's not initalized".format(name))
+        return
     
     if clone_exists:
         log_info('Updating {} in {}'.format(name, local_dir))

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -19,6 +19,7 @@ import urllib2
 
 from github_backup import __version__
 
+FNULL = open(os.devnull, 'w')
 
 def log_error(message):
     if type(message) == str:


### PR DESCRIPTION
I'm backing up my organistation using your script but we got some repo's without a initialized wiki. The script creates an error message for this. The error messages caused the crontab to mail me about an error. 

From my point of view it's not an error since there is nothing to back-up and the back-up still reflects whatever GitHub knows. From that point of view I added a test to the script to check if the repo is indeed initialized on GitHub. Skipping the repo if it's uninitialized