### PR TITLE
Add repository URL to error message for non-existing repositories

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -586,7 +586,7 @@ def fetch_repository(name, remote_url, local_dir, skip_existing=False):
                                  stderr=FNULL,
                                  shell=True)
     if initalized == 128:
-        log_info("Skipping {0} since it's not initalized".format(name))
+        log_info("Skipping {0} ({1}) since it's not initalized".format(name, remote_url))
         return
 
     if clone_exists:


### PR DESCRIPTION
This makes it easier for the user to identify which repository does not
exist or is not initialised, i.e. whether it is the main repository or
the wiki repository and which clone URL was used to check.