### PR TITLE
Add missing auth argument to _get_response()

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -256,7 +256,7 @@ def retrieve_data(args, template, query_args=None, single_request=False):
     while True:
         page = page + 1
         request = _construct_request(per_page, page, query_args, template, auth)  # noqa
-        r, errors = _get_response(request, template)
+        r, errors = _get_response(request, auth, template)
 
         status_code = int(r.getcode())
 
@@ -289,7 +289,7 @@ def get_query_args(query_args=None):
     return query_args
 
 
-def _get_response(request, template):
+def _get_response(request, auth, template):
     retry_timeout = 3
     errors = []
     # We'll make requests in a loop so we can


### PR DESCRIPTION
When running unauthenticated and Github starts rate-limiting the client,
github-backup crashes because the used auth variable in _get_response()
was not available. This change should fix it.