### PR TITLE
Add backup hooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ CLI Usage is as follows::
                      [-o OUTPUT_DIRECTORY] [--starred] [--watched] [--all]
                      [--issues] [--issue-comments] [--issue-events] [--pulls]
                      [--pull-comments] [--pull-commits] [--repositories]
-                     [--wikis] [--skip-existing]
+                     [--wikis] [--labels] [--hooks] [--skip-existing]
                      [-L [LANGUAGES [LANGUAGES ...]]] [-N NAME_REGEX]
                      [-H GITHUB_HOST] [-O] [-R REPOSITORY] [-P] [-F]
                      [--prefer-ssh] [-v]
@@ -57,6 +57,8 @@ CLI Usage is as follows::
       --pull-commits        include pull request commits in backup
       --repositories        include repository clone in backup
       --wikis               include wiki clone in backup
+      --labels              include labels in backup
+      --hooks               include web hooks in backup (works only when authenticated)
       --skip-existing       skip project if a backup directory exists
       -L [LANGUAGES [LANGUAGES ...]], --languages [LANGUAGES [LANGUAGES ...]]
                             only allow these languages
@@ -71,6 +73,6 @@ CLI Usage is as follows::
       -F, --fork            include forked repositories
       --prefer-ssh          Clone repositories using SSH instead of HTTPS
       -v, --version         show program's version number and exit
-      
+
 
 The package can be used to backup an *entire* organization or repository, including issues and wikis in the most appropriate format (clones for wikis, json files for issues).

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -159,6 +159,10 @@ def parse_args():
                         action='store_true',
                         dest='include_labels',
                         help='include labels in backup')
+    parser.add_argument('--hooks',
+                        action='store_true',
+                        dest='include_hooks',
+                        help='include hooks in backup (works only when authenticated)')
     parser.add_argument('--milestones',
                         action='store_true',
                         dest='include_milestones',
@@ -450,6 +454,9 @@ def backup_repositories(args, output_directory, repositories):
         if args.include_labels or args.include_everything:
             backup_labels(args, repo_cwd, repository, repos_template)
 
+        if args.include_hooks or args.include_everything:
+            backup_hooks(args, repo_cwd, repository, repos_template)
+
 
 def backup_issues(args, repo_cwd, repository, repos_template):
     has_issues_dir = os.path.isdir('{0}/issues/.git'.format(repo_cwd))
@@ -573,6 +580,22 @@ def backup_labels(args, repo_cwd, repository, repos_template):
                  template,
                  output_file,
                  label_cwd)
+
+
+def backup_hooks(args, repo_cwd, repository, repos_template):
+    auth = get_auth(args)
+    if not auth:
+        log_info("Skipping hooks since no authentication provided")
+        return
+    hook_cwd = os.path.join(repo_cwd, 'hooks')
+    output_file = '{0}/hooks.json'.format(hook_cwd)
+    template = '{0}/{1}/hooks'.format(repos_template,
+                                       repository['full_name'])
+    _backup_data(args,
+                 'hooks',
+                 template,
+                 output_file,
+                 hook_cwd)
 
 
 def fetch_repository(name, remote_url, local_dir, skip_existing=False):

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -304,8 +304,11 @@ def _get_response(request, auth, template):
             r = urllib2.urlopen(request)
         except urllib2.HTTPError as exc:
             errors, should_continue = _request_http_error(exc, auth, errors)  # noqa
+            r = exc
         except urllib2.URLError:
             should_continue = _request_url_error(template, retry_timeout)
+            if not should_continue:
+                raise
 
         if should_continue:
             continue


### PR DESCRIPTION
Add support for backing up repository web hooks.
This is as simple as backing up lables but works only for authenticated users hence the pre-flight check for authentication.

While testing, I noticed a problem with handling HTTP 404 errors (e.g. when querying hooks as unauthenticated user). The second commit attempts to fix them.