### PR TITLE
Prompt for password if only username given

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,15 +23,14 @@ CLI Usage is as follows::
     Github Backup [-h] [-u USERNAME] [-p PASSWORD] [-t TOKEN]
                      [-o OUTPUT_DIRECTORY] [--starred] [--watched] [--all]
                      [--issues] [--issue-comments] [--issue-events] [--pulls]
-                     [--pull-comments] [--pull-commits] [--repositories]
-                     [--wikis] [--labels] [--hooks] [--skip-existing]
-                     [-L [LANGUAGES [LANGUAGES ...]]] [-N NAME_REGEX]
-                     [-H GITHUB_HOST] [-O] [-R REPOSITORY] [-P] [-F]
-                     [--prefer-ssh] [-v]
+                     [--pull-comments] [--pull-commits] [--labels] [--hooks]
+                     [--milestones] [--repositories] [--wikis]
+                     [--skip-existing] [-L [LANGUAGES [LANGUAGES ...]]]
+                     [-N NAME_REGEX] [-H GITHUB_HOST] [-O] [-R REPOSITORY]
+                     [-P] [-F] [--prefer-ssh] [-v]
                      USER
 
-
-    Backup a github users account
+    Backup a github account
 
     positional arguments:
       USER                  github username
@@ -41,7 +40,8 @@ CLI Usage is as follows::
       -u USERNAME, --username USERNAME
                             username for basic auth
       -p PASSWORD, --password PASSWORD
-                            password for basic auth
+                            password for basic auth. If a username is given but
+                            not a password, the password will be prompted for.
       -t TOKEN, --token TOKEN
                             personal access or OAuth token
       -o OUTPUT_DIRECTORY, --output-directory OUTPUT_DIRECTORY
@@ -55,10 +55,12 @@ CLI Usage is as follows::
       --pulls               include pull requests in backup
       --pull-comments       include pull request review comments in backup
       --pull-commits        include pull request commits in backup
+      --labels              include labels in backup
+      --hooks               include hooks in backup (works only when
+                            authenticated)
+      --milestones          include milestones in backup
       --repositories        include repository clone in backup
       --wikis               include wiki clone in backup
-      --labels              include labels in backup
-      --hooks               include web hooks in backup (works only when authenticated)
       --skip-existing       skip project if a backup directory exists
       -L [LANGUAGES [LANGUAGES ...]], --languages [LANGUAGES [LANGUAGES ...]]
                             only allow these languages
@@ -66,7 +68,7 @@ CLI Usage is as follows::
                             python regex to match names against
       -H GITHUB_HOST, --github-host GITHUB_HOST
                             GitHub Enterprise hostname
-      -O, --organization    whether or not this is a query for an organization
+      -O, --organization    whether or not this is an organization user
       -R REPOSITORY, --repository REPOSITORY
                             name of repository to limit backup to
       -P, --private         include private repositories

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -7,6 +7,7 @@ import base64
 import calendar
 import codecs
 import errno
+import getpass
 import json
 import logging
 import os
@@ -109,7 +110,9 @@ def parse_args():
     parser.add_argument('-p',
                         '--password',
                         dest='password',
-                        help='password for basic auth')
+                        help='password for basic auth. '
+                             'If a username is given but not a password, the '
+                             'password will be prompted for.')
     parser.add_argument('-t',
                         '--token',
                         dest='token',
@@ -219,17 +222,18 @@ def parse_args():
 
 
 def get_auth(args):
-    auth = None
     if args.token:
-        auth = base64.b64encode(args.token + ':' + 'x-oauth-basic')
-    elif args.username and args.password:
-        auth = base64.b64encode(args.username + ':' + args.password)
-    elif args.username and not args.password:
-        log_error('You must specify a password for basic auth')
-    elif args.password and not args.username:
+        return base64.b64encode(args.token + ':' + 'x-oauth-basic')
+
+    if args.username:
+        if not args.password:
+            args.password = getpass.getpass()
+        return base64.b64encode(args.username + ':' + args.password)
+
+    if args.password:
         log_error('You must specify a username for basic auth')
 
-    return auth
+    return None
 
 
 def get_github_api_host(args):


### PR DESCRIPTION
It's nice to not have to enter a password in a command so that it can't be seen by anyone looking over your shoulder or in your shell history.
Incidentally, the README should be updated with new CLI usage, not just for this but also for the milestones option.