### PR TITLE
Fix reading user's private repositories

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -382,9 +382,8 @@ def _request_url_error(template, retry_timeout):
 def retrieve_repositories(args):
     log_info('Retrieving repositories')
     single_request = False
-    template = 'https://{0}/users/{1}/repos'.format(
-        get_github_api_host(args),
-        args.user)
+    template = 'https://{0}/user/repos'.format(
+        get_github_api_host(args))
     if args.organization:
         template = 'https://{0}/orgs/{1}/repos'.format(
             get_github_api_host(args),
@@ -402,6 +401,9 @@ def retrieve_repositories(args):
 
 def filter_repositories(args, repositories):
     log_info('Filtering repositories')
+
+    repositories = [r for r in repositories if r['owner']['login'] == args.user]
+
     name_regex = None
     if args.name_regex:
         name_regex = re.compile(args.name_regex)


### PR DESCRIPTION
I noticed that private repositories outside of organizations are not automatically detected and traced it to the fact that the `retrieve_repositories` function is only getting a list of public repositories - https://developer.github.com/v3/repos/#list-user-repositories.  I'm fixing that by using https://developer.github.com/v3/repos/#list-your-repositories which includes public and private repositories by default, then filtering for the correct owner's repositories later.  