### PR TITLE
Softly fail if not able to read hooks

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -598,11 +598,14 @@ def backup_hooks(args, repo_cwd, repository, repos_template):
     output_file = '{0}/hooks.json'.format(hook_cwd)
     template = '{0}/{1}/hooks'.format(repos_template,
                                        repository['full_name'])
-    _backup_data(args,
-                 'hooks',
-                 template,
-                 output_file,
-                 hook_cwd)
+    try:
+        _backup_data(args,
+                     'hooks',
+                     template,
+                     output_file,
+                     hook_cwd)
+    except SystemExit:
+        log_info("Unable to read hooks, skipping")
 
 
 def fetch_repository(name, remote_url, local_dir, skip_existing=False):


### PR DESCRIPTION
Fixes #27 

This makes failures to read a repo's webhooks be a soft failure.  It's a bit hacky and could use some refactoring* but it's the simplest fix I could do.  

*Refactor to make `_backup_data` raise an exception that propagates up the call stack which would be caught and processed higher up.  This would give a chance for more functions to handle error conditions.  