### PR TITLE
Don't install over insecure connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Using PIP via PyPI::
 
 Using PIP via Github::
 
-    pip install git+git://github.com/josegonzalez/python-github-backup.git#egg=github-backup
+    pip install git+https://github.com/josegonzalez/python-github-backup.git#egg=github-backup
 
 Usage
 =====


### PR DESCRIPTION
The `git://` protocol is unauthenticated and unencrypted, and no longer advertised by GitHub. Using HTTPS shouldn't impact performance.