### PR TITLE
Fix remotes while updating repository

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -769,7 +769,7 @@ def fetch_repository(name,
 
         remotes = subprocess.check_output(['git', 'remote', 'show'],
                                           cwd=local_dir)
-        remotes = [i.strip() for i in remotes.decode('utf-8')]
+        remotes = [i.strip() for i in remotes.decode('utf-8').splitlines()]
 
         if 'origin' not in remotes:
             git_command = ['git', 'remote', 'rm', 'origin']


### PR DESCRIPTION
Without that you get `remotes=[u'o', u'r', u'i', u'g', u'i', u'n', u'']`, which is clearly wrong