### PR TITLE
update check_io() to allow scripts to run on Windows

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -74,6 +74,7 @@ def logging_subprocess(popenargs,
                  child.stderr: stderr_log_level}
 
     def check_io():
+        if sys.platform == 'win32': return
         ready_to_read = select.select([child.stdout, child.stderr],
                                       [],
                                       [],

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -69,12 +69,15 @@ def logging_subprocess(popenargs,
     """
     child = subprocess.Popen(popenargs, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, **kwargs)
+    if sys.platform == 'win32':
+        log_info("Windows operating system detected - no subprocess logging will be returned")
 
     log_level = {child.stdout: stdout_log_level,
                  child.stderr: stderr_log_level}
 
     def check_io():
-        if sys.platform == 'win32': return
+        if sys.platform == 'win32':
+            return
         ready_to_read = select.select([child.stdout, child.stderr],
                                       [],
                                       [],


### PR DESCRIPTION
Since there is no equivalent Windows call to `select.select` - this addition skips the subprocess reporting which allows the script to continue running and successfully back up repositories on Windows.

I believe this addresses #56 and #41 - it's not a pretty solution - finding a better way to report the subprocesses would be preferred - but it works. 