### PR TITLE
Mark string as binary in comparison for skip_existing

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -831,7 +831,7 @@ def fetch_repository(name,
             clone_exists = subprocess.check_output(['git',
                                                     'rev-parse',
                                                     '--is-bare-repository'],
-                                                   cwd=local_dir) == "true\n"
+                                                   cwd=local_dir) == b"true\n"
         else:
             clone_exists = False
     else:


### PR DESCRIPTION
Found out that the flag "--skip-existing" did not work out as expected on Python
3.6. Tracked it down to the comparison which has to be against a string of bytes
in Python3.

Note: I think there might be a problem if Python 2.6 support is still required, not sure if the binary string syntax would work there. 