### PR TITLE
Workaround gist clone in `--prefer-ssh` mode

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -387,11 +387,11 @@ def get_github_host(args):
 
 
 def get_github_repo_url(args, repository):
-    if args.prefer_ssh:
-        return repository['ssh_url']
-
     if repository.get('is_gist'):
         return repository['git_pull_url']
+
+    if args.prefer_ssh:
+        return repository['ssh_url']
 
     auth = get_auth(args, False)
     if auth:


### PR DESCRIPTION
Fixes #127 

There is no reliable way to build SSH clone URL for gists using Github API, especially in on premises case.

Actual PR moves gist check to be performed earlier and returns valid clone URL without regard of SSH preference. It appears as a legit solution to me since `--prefer-ssh` parameter does not enforce SSH mode, but only sets preference.