### PR TITLE
Crash when an release asset doesn't exist

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -582,14 +582,14 @@ def download_file(url, path, auth):
                 f.write(chunk)
     except HTTPError as exc:
         # Gracefully handle 404 responses (and others) when downloading from S3
-        log_info('Skipping download of asset {0} due to HTTPError: {1}'.format(url, exc.reason))
+        log_warning('Skipping download of asset {0} due to HTTPError: {1}'.format(url, exc.reason))
     except URLError as e:
         # Gracefully hadnle other URL errors
-        log_info('Skipping download of asset {0} due to URLError: {1}'.format(url, e.reason))
+        log_warning('Skipping download of asset {0} due to URLError: {1}'.format(url, e.reason))
     except socket.error as e:
         # Gracefully handle socket errors
         # TODO: Implement retry logic
-        log_info('Skipping download of asset {0} due to socker error: {1}'.format(url, e.strerror))
+        log_warning('Skipping download of asset {0} due to socker error: {1}'.format(url, e.strerror))
 
 
 def get_authenticated_user(args):

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -569,15 +569,27 @@ def download_file(url, path, auth):
     request.add_header('Accept', 'application/octet-stream')
     request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
     opener = build_opener(S3HTTPRedirectHandler)
-    response = opener.open(request)
 
-    chunk_size = 16 * 1024
-    with open(path, 'wb') as f:
-        while True:
-            chunk = response.read(chunk_size)
-            if not chunk:
-                break
-            f.write(chunk)
+    try:
+        response = opener.open(request)
+
+        chunk_size = 16 * 1024
+        with open(path, 'wb') as f:
+            while True:
+                chunk = response.read(chunk_size)
+                if not chunk:
+                    break
+                f.write(chunk)
+    except HTTPError as exc:
+        # Gracefully handle 404 responses (and others) when downloading from S3
+        log_info('Skipping download of asset {0} due to HTTPError: {1}'.format(url, exc.reason))
+    except URLError as e:
+        # Gracefully hadnle other URL errors
+        log_info('Skipping download of asset {0} due to URLError: {1}'.format(url, e.reason))
+    except socket.error as e:
+        # Gracefully handle socket errors
+        # TODO: Implement retry logic
+        log_info('Skipping download of asset {0} due to socker error: {1}'.format(url, e.strerror))
 
 
 def get_authenticated_user(args):

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -584,7 +584,7 @@ def download_file(url, path, auth):
         # Gracefully handle 404 responses (and others) when downloading from S3
         log_warning('Skipping download of asset {0} due to HTTPError: {1}'.format(url, exc.reason))
     except URLError as e:
-        # Gracefully hadnle other URL errors
+        # Gracefully handle other URL errors
         log_warning('Skipping download of asset {0} due to URLError: {1}'.format(url, e.reason))
     except socket.error as e:
         # Gracefully handle socket errors


### PR DESCRIPTION
Currently, the script crashes whenever a release asset is unable to download (for example a 404 response). This change instead logs the failure and allows the script to continue. No retry logic is enabled, but at least it prevents the crash and allows the backup to complete. Retry logic can be implemented later if wanted.

closes https://github.com/josegonzalez/python-github-backup/issues/129

Original result when asset fails to download:

```
Cloning reicast-emulator repository from https://*****:x-oauth-basic@github.com/reicast/reicast-emulator.git to /Users/bbaron/tmp/github-backup/starred/reicast/reicast-emulator/repository
Retrieving reicast/reicast-emulator issues
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues?per_page=100&page=1&filter=all&state=open&since=2020-01-03T22%3A21%3A33Z
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues?per_page=100&page=1&filter=all&state=closed&since=2020-01-03T22%3A21%3A33Z
Saving 0 issues to disk
Retrieving reicast/reicast-emulator pull requests
Requesting https://api.github.com/repos/reicast/reicast-emulator/pulls?per_page=100&page=1&filter=all&state=open&sort=updated&direction=desc
Requesting https://api.github.com/repos/reicast/reicast-emulator/pulls?per_page=100&page=1&filter=all&state=closed&sort=updated&direction=desc
Saving 0 pull requests to disk
Retrieving reicast/reicast-emulator milestones
Requesting https://api.github.com/repos/reicast/reicast-emulator/milestones?per_page=100&page=1&state=all
Saving 9 milestones to disk
Retrieving einsteinx2 labels
Requesting https://api.github.com/repos/reicast/reicast-emulator/labels?per_page=100&page=1
Writing 64 labels to disk
Retrieving reicast/reicast-emulator releases
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases?per_page=100&page=1
Saving 7 releases to disk
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/18970705/assets?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/18607180/assets?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/18598619/assets?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/12856493/assets?per_page=100&page=1
Traceback (most recent call last):
  File "/Users/bbaron/.platformio/penv/bin/github-backup", line 1117, in <module>
    main()
  File "/Users/bbaron/.platformio/penv/bin/github-backup", line 1112, in main
    backup_repositories(args, output_directory, repositories)
  File "/Users/bbaron/.platformio/penv/bin/github-backup", line 752, in backup_repositories
    include_assets=args.include_assets or args.include_everything)
  File "/Users/bbaron/.platformio/penv/bin/github-backup", line 962, in backup_releases
    download_file(asset['url'], os.path.join(release_cwd, asset['name']), get_auth(args))
  File "/Users/bbaron/.platformio/penv/bin/github-backup", line 572, in download_file
    response = opener.open(request)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 563, in error
    result = self._call_chain(*args)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 755, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```

Output with this change implemented:

```
Updating reicast-emulator in /Users/bbaron/tmp/github-backup/starred/reicast/reicast-emulator/repository
Retrieving reicast/reicast-emulator issues
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues?per_page=100&page=1&filter=all&state=open&since=2020-01-03T22%3A21%3A33Z
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues?per_page=100&page=1&filter=all&state=closed&since=2020-01-03T22%3A21%3A33Z
Saving 2 issues to disk
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues/1749/comments?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues/1749/events?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues/1716/comments?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/issues/1716/events?per_page=100&page=1
Retrieving reicast/reicast-emulator pull requests
Requesting https://api.github.com/repos/reicast/reicast-emulator/pulls?per_page=100&page=1&filter=all&state=open&sort=updated&direction=desc
Requesting https://api.github.com/repos/reicast/reicast-emulator/pulls?per_page=100&page=1&filter=all&state=closed&sort=updated&direction=desc
Saving 0 pull requests to disk
Retrieving reicast/reicast-emulator milestones
Requesting https://api.github.com/repos/reicast/reicast-emulator/milestones?per_page=100&page=1&state=all
Saving 9 milestones to disk
Retrieving einsteinx2 labels
Requesting https://api.github.com/repos/reicast/reicast-emulator/labels?per_page=100&page=1
Writing 64 labels to disk
Retrieving reicast/reicast-emulator releases
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases?per_page=100&page=1
Saving 7 releases to disk
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/18970705/assets?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/18607180/assets?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/18598619/assets?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/12856493/assets?per_page=100&page=1
Skipping download of asset https://api.github.com/repos/reicast/reicast-emulator/releases/assets/8640991 due to HTTPError: Not Found
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/12254973/assets?per_page=100&page=1
Skipping download of asset https://api.github.com/repos/reicast/reicast-emulator/releases/assets/8128776 due to HTTPError: Not Found
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/773524/assets?per_page=100&page=1
Requesting https://api.github.com/repos/reicast/reicast-emulator/releases/537488/assets?per_page=100&page=1
Skipping download of asset https://api.github.com/repos/reicast/reicast-emulator/releases/assets/229553 due to HTTPError: Not Found
```