### PR TITLE
Fixed macOS keychain access when using Python 3

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -337,6 +337,8 @@ def get_auth(args, encode=True):
                         '-s', args.osx_keychain_item_name,
                         '-a', args.osx_keychain_item_account,
                         '-w'], stderr=devnull).strip())
+                if not PY2:
+                    token = token.decode('utf-8')
                 auth = token + ':' + 'x-oauth-basic'
             except:
                 log_error('No password item matching the provided name and account could be found in the osx keychain.')


### PR DESCRIPTION
Python 3 is returning bytes rather than a string, so the string concatenation to create the auth variable was throwing an exception which the script was interpreting to mean it couldn't find the password. Adding a conversion to string first fixed the issue.