### PR TITLE
Public repos no longer include the auth token

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -394,7 +394,7 @@ def get_github_repo_url(args, repository):
         return repository['ssh_url']
 
     auth = get_auth(args, False)
-    if auth:
+    if auth and repository['private'] == True:
         repo_url = 'https://{0}@{1}/{2}/{3}.git'.format(
             auth,
             get_github_host(args),


### PR DESCRIPTION
Tested thoroughly and this one line change works as expected. The auth token is used to clone only when the repo is private and requires authentication to clone, for all public repos that can be cloned without a token, it now just uses the regular https url without any basic auth so when running `git remote -v` you can no longer see the token.

This will not change repos that have already been backed up unless the `origin` remote has been removed for some reason as otherwise it just performs a `git fetch`. If `origin` has been removed, it will use the new remote url which will also work fine.

---

When backing up repositories using an auth token and https, the GitHub personal auth token is leaked in each backed up repository. It is included in the URL of each repository's git remote url.

This is not needed as they are public and can be accessed without the token and can cause issues in the future if the token is ever changed, so I think it makes more sense not to have the token stored in each repo backup. I think the token should only be "leaked" like this out of necessity, e.g. it's a private repository and the --prefer-ssh option was not chosen so https with auth token was required to perform the clone.

closes https://github.com/josegonzalez/python-github-backup/issues/134