### PR TITLE
Fixed script fails if not installed from pip

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -41,7 +41,11 @@ except ImportError:
     from urllib2 import HTTPRedirectHandler
     from urllib2 import build_opener
 
-from github_backup import __version__
+try:
+    from github_backup import __version__
+    VERSION = __version__
+except ImportError:
+    VERSION = 'unknown'
 
 FNULL = open(os.devnull, 'w')
 
@@ -302,7 +306,7 @@ def parse_args():
                         help='Clone repositories using SSH instead of HTTPS')
     parser.add_argument('-v', '--version',
                         action='version',
-                        version='%(prog)s ' + __version__)
+                        version='%(prog)s ' + VERSION)
     parser.add_argument('--keychain-name',
                         dest='osx_keychain_item_name',
                         help='OSX ONLY: name field of password item in OSX keychain that holds the personal access or OAuth token')


### PR DESCRIPTION
At the top of the script, the line from github_backup import __version__ gets the script's version number to use if the script is called with the -v or --version flags. The problem is that if the script hasn't been installed via pip (for example I cloned the repo directly to my backup server), the script will fail due to an import exception.

Also presumably it will always use the version number from pip even if running a modified version from git or a fork or something, though this does not fix that as I have no idea how to check if it's running the pip installed version or not. But at least the script will now work fine if cloned from git or just copied to another machine.

closes https://github.com/josegonzalez/python-github-backup/issues/141