### PR TITLE
Remove deprecated (and removed) "git lfs fetch" flags

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -1032,7 +1032,7 @@ def fetch_repository(name,
             logging_subprocess(git_command, None, cwd=local_dir)
 
         if lfs_clone:
-            git_command = ['git', 'lfs', 'fetch', '--all', '--force', '--tags', '--prune']
+            git_command = ['git', 'lfs', 'fetch', '--all', '--prune']
         else:
             git_command = ['git', 'fetch', '--all', '--force', '--tags', '--prune']
         logging_subprocess(git_command, None, cwd=local_dir)


### PR DESCRIPTION
"--tags" and "--force" were removed at some point from [`git lfs fetch`](https://manpages.debian.org/testing/git-lfs/git-lfs-fetch.1.en.html). This broke our backup script.