### PR TITLE
Add logic for transforming gist repository urls to ssh

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -419,7 +419,13 @@ def get_github_host(args):
 
 def get_github_repo_url(args, repository):
     if repository.get('is_gist'):
-        return repository['git_pull_url']
+        if args.prefer_ssh:
+            # The git_pull_url value is always https for gists, so we need to transform it to ssh form
+            repo_url = re.sub('^https?:\/\/(.+)\/(.+)\.git$', r'git@\1:\2.git', repository['git_pull_url'])
+            repo_url = re.sub('^git@gist\.', 'git@', repo_url) # strip gist subdomain for better hostkey compatibility
+        else:
+            repo_url = repository['git_pull_url']
+        return repo_url
 
     if args.prefer_ssh:
         return repository['ssh_url']


### PR DESCRIPTION
This PR constructs an SSH url for gist repositories when gists are included and `--prefer-ssh` is set. 

The values are predictable for the most part, since github.com and enterprise server instances using subdomain isolation will use `gist.<domain>/<id>.git`, while the enterprise server instances without subdomain isolation will be `<domain>/gist/<id>.git`.  

This implementation also removes the prefixed `gist` subdomain, since it is more likely that the bare domain will have a trusted host key than the `gist` subdomain, and the cloning functionality for gists works on both (tested on both github.com and enterprise server 1.20.9).  

This should result in a standardized SSH url that can be used on all hosting platforms. 

@Snawoot Do you have any additional thoughts on this, since you indicated in your PR #128 that calculating an SSH url was not reliable