### PR TITLE
Make API request throttling optional

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -457,7 +457,7 @@ def retrieve_data_gen(args, template, query_args=None, single_request=False):
         status_code = int(r.getcode())
         # be gentle with API request limit and throttle requests if remaining requests getting low
         limit_remaining = int(r.headers.get('x-ratelimit-remaining', 0))
-        if limit_remaining <= args.throttle_limit:
+        if args.throttle_limit and limit_remaining <= args.throttle_limit:
             log_info(
                 'API request limit hit: {} requests left, pausing further requests for {}s'.format(
                     limit_remaining,


### PR DESCRIPTION
https://github.com/josegonzalez/python-github-backup/pull/149 introduced arguments to enable API request throttling, but the logic implements throttling by default with a 30 second timeout if `x-ratelimit-remaining` is not set by the server, crippling performance. This small change restores the original behaviour when `--throttle-limit` is not specified while keeping the new throttling behaviour if selected.