### PR TITLE
Include --private flag in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,10 +153,10 @@ Instructions on how to do this can be found on https://git-lfs.github.com.
 Examples
 ========
 
-Backup all repositories::
+Backup all repositories, including private ones::
 
     export ACCESS_TOKEN=SOME-GITHUB-TOKEN
-    github-backup WhiteHouse --token $ACCESS_TOKEN --organization --output-directory /tmp/white-house --repositories
+    github-backup WhiteHouse --token $ACCESS_TOKEN --organization --output-directory /tmp/white-house --repositories --private
 
 Backup a single organization repository with everything else (wiki, pull requests, comments, issues etc)::
 


### PR DESCRIPTION
By default, private repositories are not included. This is surprising.
It took me a while to figure this out, and making that clear in the
example can help others to be aware of that.