### PR TITLE
fix: Always clone with OAuth token when provided

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -420,7 +420,7 @@ def get_github_repo_url(args, repository):
         return repository['ssh_url']
 
     auth = get_auth(args, encode=False, for_git_cli=True)
-    if auth and repository['private'] is True:
+    if auth:
         repo_url = 'https://{0}@{1}/{2}/{3}.git'.format(
             auth,
             get_github_host(args),


### PR DESCRIPTION
Github Enterprise servers with 'Anonymous Git read access' disabled cause `git ls-remote` to fail (128) when cloning from a repo's `clone_url`. Using the OAuth token when provided allows cloning private AND public repos when Anonymous Git read access is disabled.