### PR TITLE
Try to make compatible code with direct Python call ; reduce the hard link of the code with the cli

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -15,7 +15,11 @@ from github_backup.github_backup import (
     retrieve_repositories,
 )
 
-logging.basicConfig(format='%(asctime)s.%(msecs)03d: %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
+logging.basicConfig(
+    format='%(asctime)s.%(msecs)03d: %(message)s',
+    datefmt='%Y-%m-%dT%H:%M:%S',
+    level=logging.INFO
+)
 
 def main():
     args = parse_args()

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os
+import os, sys, logging
 
 from github_backup.github_backup import (
     backup_account,
@@ -9,11 +9,13 @@ from github_backup.github_backup import (
     filter_repositories,
     get_authenticated_user,
     log_info,
+    log_warning,
     mkdir_p,
     parse_args,
     retrieve_repositories,
 )
 
+logging.basicConfig(format='%(asctime)s.%(msecs)03d: %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
 
 def main():
     args = parse_args()
@@ -39,4 +41,8 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except Exception as e:
+        log_warning(str(e))
+        sys.exit(1)


### PR DESCRIPTION
Hi,

I started to use this code to backup my repositories, but I use it directly with Python.

The main problems :
- Forcing to pass an USER in the command (after I make a `args.user = os.environ['USER']` to change it, it's okay)
- In case of "error", the script will exit ; what I don't want
- Logs are directly writen in stdout and stderr, so I can't format them

I tryed in this MR to make the smaller changes as possible with the same behavior for CLI :
- args can be passed to parse_args()
- Use of logging module to be able to change formatting
- Errors are now Exceptions and catched by the cli file to be transformated to a log + exit

We need to test all is okay, but I can detect a small change : log time uses now 3 decimals for microseconds and no more 6.

Regards,