### PR TITLE
Fix Organization backup

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -277,9 +277,8 @@ def parse_args(args = None):
                         help='GitHub Enterprise hostname')
     parser.add_argument('-O',
                         '--organization',
-                        action='store_true',
                         dest='organization',
-                        help='whether or not this is an organization user')
+                        help='The name of the user organization')
     parser.add_argument('-R',
                         '--repository',
                         dest='repository',
@@ -652,7 +651,7 @@ def retrieve_repositories(args, authenticated_user):
     if args.organization:
         template = 'https://{0}/orgs/{1}/repos'.format(
             get_github_api_host(args),
-            args.user)
+            args.organization)
 
     if args.repository:
         single_request = True


### PR DESCRIPTION
The organization backup not works. Because the url correct is '/orgs/{org}/repos' not '/orgs/{user}/repos'

You can see it here https://docs.github.com/en/rest/reference/repos#list-organization-repositories