### PR TITLE
Fix lint issues raised by Flake8

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -11,7 +11,6 @@ import datetime
 import errno
 import getpass
 import json
-import logging
 import os
 import re
 import select
@@ -41,6 +40,7 @@ FNULL = open(os.devnull, 'w')
 
 def _get_log_date():
     return datetime.datetime.isoformat(datetime.datetime.now())
+
 
 def log_info(message):
     """
@@ -133,7 +133,7 @@ def mask_password(url, secret='*****'):
     return url.replace(parsed.password, secret)
 
 
-def parse_args(args = None):
+def parse_args(args=None):
     parser = argparse.ArgumentParser(description='Backup a github account')
     parser.add_argument('user',
                         metavar='USER',


### PR DESCRIPTION
According to job: 
[ https://app.circleci.com/pipelines/github/josegonzalez/python-github-backup/30/workflows/74eb93f2-2505-435d-b728-03b3cc04c14a/jobs/23 ]

Failed on the following checks:
./github_backup/github_backup.py:20:1: F811 redefinition of unused 'logging' from line 14
./github_backup/github_backup.py:45:1: E302 expected 2 blank lines, found 1
./github_backup/github_backup.py:136:20: E251 unexpected spaces around keyword / parameter equals