### PR TITLE
git lfs clone does not respect --mirror

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -1106,16 +1106,17 @@ def fetch_repository(name,
             masked_remote_url,
             local_dir))
         if bare_clone:
+            git_command = ['git', 'clone', '--mirror', remote_url, local_dir]
+            logging_subprocess(git_command, None)
             if lfs_clone:
-                git_command = ['git', 'lfs', 'clone', '--mirror', remote_url, local_dir]
-            else:
-                git_command = ['git', 'clone', '--mirror', remote_url, local_dir]
+                git_command = ['git', 'lfs', 'fetch', '--all', '--prune']
+                logging_subprocess(git_command, None, cwd=local_dir)
         else:
             if lfs_clone:
                 git_command = ['git', 'lfs', 'clone', remote_url, local_dir]
             else:
                 git_command = ['git', 'clone', remote_url, local_dir]
-        logging_subprocess(git_command, None)
+            logging_subprocess(git_command, None)
 
 
 def backup_account(args, output_directory):


### PR DESCRIPTION
Running github-backup with both --lfs and --mirror arguments, the LFS files are not downloaded.
This problably is because https://github.com/git-lfs/git-lfs/issues/2342
A recommended way to mirror a repository with LFS seems to be to clone it first, then fetch LFS files, as indicated in the first steps of https://docs.github.com/en/repositories/creating-and-managing-repositories/duplicating-a-repository#mirroring-a-repository-that-contains-git-large-file-storage-objects
