### PR TITLE
Refactor logging and add support for quiet flag

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -2,38 +2,41 @@
 
 import os, sys, logging
 
-from github_backup.github_backup import (
-    backup_account,
-    backup_repositories,
-    check_git_lfs_install,
-    filter_repositories,
-    get_authenticated_user,
-    log_info,
-    log_warning,
-    mkdir_p,
-    parse_args,
-    retrieve_repositories,
-)
-
 logging.basicConfig(
     format='%(asctime)s.%(msecs)03d: %(message)s',
     datefmt='%Y-%m-%dT%H:%M:%S',
     level=logging.INFO
 )
 
+from github_backup.github_backup import (
+    backup_account,
+    backup_repositories,
+    check_git_lfs_install,
+    filter_repositories,
+    get_authenticated_user,
+    logger,
+    mkdir_p,
+    parse_args,
+    retrieve_repositories,
+)
+
+
 def main():
     args = parse_args()
 
+    if args.quiet:
+        logger.setLevel(logging.WARNING)
+
     output_directory = os.path.realpath(args.output_directory)
     if not os.path.isdir(output_directory):
-        log_info('Create output directory {0}'.format(output_directory))
+        logger.info('Create output directory {0}'.format(output_directory))
         mkdir_p(output_directory)
 
     if args.lfs_clone:
         check_git_lfs_install()
 
     if not args.as_app:
-        log_info('Backing up user {0} to {1}'.format(args.user, output_directory))
+        logger.info('Backing up user {0} to {1}'.format(args.user, output_directory))
         authenticated_user = get_authenticated_user(args)
     else:
         authenticated_user = {'login': None}
@@ -48,5 +51,5 @@ if __name__ == '__main__':
     try:
         main()
     except Exception as e:
-        log_warning(str(e))
+        logger.warning(str(e))
         sys.exit(1)


### PR DESCRIPTION
- Replace local `log_info` and `log_warning` functions with a module `logger` and `logger.info`/`logger.warning`
- Add support for `--quiet` flag by setting the level on the logger
- Resolves #190 
- This also does a little bit of setup for #182 as a module logger would be required to set different log handlers for different log levels