### PR TITLE
Add --log-level command line argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,15 +30,15 @@ Usage
 CLI Usage is as follows::
 
     github-backup [-h] [-u USERNAME] [-p PASSWORD] [-t TOKEN] [--as-app]
-                  [-o OUTPUT_DIRECTORY] [-i] [--starred] [--all-starred]
-                  [--watched] [--followers] [--following] [--all]
-                  [--issues] [--issue-comments] [--issue-events] [--pulls]
-                  [--pull-comments] [--pull-commits] [--pull-details]
-                  [--labels] [--hooks] [--milestones] [--repositories]
-                  [--bare] [--lfs] [--wikis] [--gists] [--starred-gists]
-                  [--skip-existing] [-L [LANGUAGES [LANGUAGES ...]]]
-                  [-N NAME_REGEX] [-H GITHUB_HOST] [-O] [-R REPOSITORY]
-                  [-P] [-F] [--prefer-ssh] [-v]
+                  [-o OUTPUT_DIRECTORY] [-l LOG_LEVEL] [-i] [--starred]
+                  [--all-starred] [--watched] [--followers] [--following]
+                  [--all] [--issues] [--issue-comments] [--issue-events]
+                  [--pulls] [--pull-comments] [--pull-commits]
+                  [--pull-details] [--labels] [--hooks] [--milestones]
+                  [--repositories] [--bare] [--lfs] [--wikis] [--gists]
+                  [--starred-gists] [--skip-archived] [--skip-existing]
+                  [-L [LANGUAGES ...]] [-N NAME_REGEX] [-H GITHUB_HOST]
+                  [-O] [-R REPOSITORY] [-P] [-F] [--prefer-ssh] [-v]
                   [--keychain-name OSX_KEYCHAIN_ITEM_NAME]
                   [--keychain-account OSX_KEYCHAIN_ITEM_ACCOUNT]
                   [--releases] [--assets] [--throttle-limit THROTTLE_LIMIT]
@@ -63,6 +63,9 @@ CLI Usage is as follows::
       --as-app              authenticate as github app instead of as a user.
       -o OUTPUT_DIRECTORY, --output-directory OUTPUT_DIRECTORY
                             directory at which to backup the repositories
+      -l LOG_LEVEL, --log-level LOG_LEVEL
+                            log level to use (default: info, possible levels:
+                            debug, info, warning, error, critical)
       -i, --incremental     incremental backup
       --starred             include JSON output of starred repositories in backup
       --all-starred         include starred repositories in backup [*]

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -32,6 +32,11 @@ def main():
     if args.lfs_clone:
         check_git_lfs_install()
 
+    if args.log_level:
+        log_level = logging.getLevelName(args.log_level.upper())
+        if isinstance(log_level, int):
+            logging.root.setLevel(log_level)
+
     if not args.as_app:
         log_info('Backing up user {0} to {1}'.format(args.user, output_directory))
         authenticated_user = get_authenticated_user(args)

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -162,6 +162,11 @@ def parse_args(args=None):
                         default='.',
                         dest='output_directory',
                         help='directory at which to backup the repositories')
+    parser.add_argument('-l',
+                        '--log-level',
+                        default='info',
+                        dest='log_level',
+                        help='log level to use (default: info, possible levels: debug, info, warning, error, critical)')
     parser.add_argument('-i',
                         '--incremental',
                         action='store_true',


### PR DESCRIPTION
Support changing the log level to the desired value easily.
For example, this is useful to suppress progress messages but
keep logging warnings and errors.