### PR TITLE
Add option to exclude repositories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,8 @@ CLI Usage is as follows::
                   [-P] [-F] [--prefer-ssh] [-v]
                   [--keychain-name OSX_KEYCHAIN_ITEM_NAME]
                   [--keychain-account OSX_KEYCHAIN_ITEM_ACCOUNT]
-                  [--releases] [--assets] [--throttle-limit THROTTLE_LIMIT]
-                  [--throttle-pause THROTTLE_PAUSE]
+                  [--releases] [--assets] [--exclude [REPOSITORY [REPOSITORY ...]]
+                  [--throttle-limit THROTTLE_LIMIT] [--throttle-pause THROTTLE_PAUSE]
                   USER
 
     Backup a github account
@@ -112,6 +112,8 @@ CLI Usage is as follows::
                             binaries
       --assets              include assets alongside release information; only
                             applies if including releases
+      --exclude [REPOSITORY [REPOSITORY ...]]
+                            names of repositories to exclude from backup.
       --throttle-limit THROTTLE_LIMIT
                             start throttling of GitHub API requests after this
                             amount of API requests remain

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -324,6 +324,10 @@ def parse_args(args=None):
                         type=float,
                         default=30.0,
                         help='wait this amount of seconds when API request throttling is active (default: 30.0, requires --throttle-limit to be set)')
+    parser.add_argument('--exclude',
+                        dest='exclude',
+                        help='names of repositories to exclude',
+                        nargs="*")
     return parser.parse_args(args)
 
 
@@ -750,6 +754,8 @@ def filter_repositories(args, unfiltered_repositories):
         repositories = [r for r in repositories if name_regex.match(r['name'])]
     if args.skip_archived:
         repositories = [r for r in repositories if not r.get('archived')]
+    if args.exclude:
+        repositories = [r for r in repositories if r['name'] not in args.exclude]
 
     return repositories
 


### PR DESCRIPTION
Add an option to exclude named repositories from the backup
`--exclude [REPOSITORY [REPOSITORY ...]]`

closes #203

could be used to work around issue #135 