### PR TITLE
Add support for fine-grained tokens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,8 @@ Usage
 
 CLI Usage is as follows::
 
-    github-backup [-h] [-u USERNAME] [-p PASSWORD] [-t TOKEN] [--as-app]
+    github-backup [-h] [-u USERNAME] [-p PASSWORD]  
+                  [-t TOKEN_CLASSIC] [-f TOKEN_FINE] [--as-app]
                   [-o OUTPUT_DIRECTORY] [-i] [--starred] [--all-starred]
                   [--watched] [--followers] [--following] [--all]
                   [--issues] [--issue-comments] [--issue-events] [--pulls]
@@ -57,7 +58,9 @@ CLI Usage is as follows::
       -p PASSWORD, --password PASSWORD
                             password for basic auth. If a username is given but
                             not a password, the password will be prompted for.
-      -t TOKEN, --token TOKEN
+      -f TOKEN_FINE, --token-fine TOKEN
+                            fine-grained personal access token
+      -t TOKEN_CLASSIC, --token-classic TOKEN
                             personal access, OAuth, or JSON Web token, or path to
                             token (file://...)
       --as-app              authenticate as github app instead of as a user.
@@ -160,13 +163,13 @@ Backup all repositories, including private ones::
     export ACCESS_TOKEN=SOME-GITHUB-TOKEN
     github-backup WhiteHouse --token $ACCESS_TOKEN --organization --output-directory /tmp/white-house --repositories --private
 
-Backup a single organization repository with everything else (wiki, pull requests, comments, issues etc)::
+Use a fine-grained access token to backup a single organization repository with everything else (wiki, pull requests, comments, issues etc)::
 
     export ACCESS_TOKEN=SOME-GITHUB-TOKEN
     ORGANIZATION=docker
     REPO=cli
     # e.g. git@github.com:docker/cli.git
-    github-backup $ORGANIZATION -P -t $ACCESS_TOKEN -o . --all -O -R $REPO
+    github-backup $ORGANIZATION -P -f $ACCESS_TOKEN -o . --all -O -R $REPO
 
 Testing
 =======


### PR DESCRIPTION
# Summary

This PR adds support for the beta fine-grained personal access tokens (PAT)

# Changes implemented

* Adds a new command line argument, `token_fine` with the new `-f` flag to support the new token format.
* Modifies the existing `token` command line argument into `token_classic`, keeping the flag `-t`

# Issues addressed
This PR addresses https://github.com/josegonzalez/python-github-backup/issues/205