### PR TITLE
feat: create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9.18-slim
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y git git-lfs
+
+WORKDIR /usr/src/app
+
+COPY release-requirements.txt .
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r release-requirements.txt
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install .
+
+ENTRYPOINT [ "github-backup" ]


### PR DESCRIPTION
The resulting image can be used like `docker run ghcr.io/pl4nty/github-backup pl4nty --token $TOKEN`. With some docs and a first-party image via GitHub Actions, this could close #211.

It might also be usable for local development, but I'm not sure of the difference between `requirements.txt` and `release-requirements.txt`. I used the latter.

Build results: https://github.com/pl4nty/containers/actions/runs/6675073097/job/18142653711