### PR TITLE
Added automatic release workflow, for use with GitHub Actions

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,0 +1,38 @@
+name: automatic-release
+
+on:
+    workflow_dispatch:
+        inputs:
+            release_type:
+                description: Release type
+                required: true
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
+
+jobs:
+    release:
+        name: Release
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            - name: Setup Git
+              run: |
+                git config --local user.email "action@github.com"
+                git config --local user.name "GitHub Action"
+            - name: Setup Python
+              uses: actions/setup-python@v4
+              with:
+                python-version: '3.8'
+            - name: Install prerequisites
+              run: pip install -r release-requirements.txt
+            - name: Execute release
+              env:
+                SEMVER_BUMP: ${{ github.event.inputs.release_type }}
+                TWINE_REPOSITORY: ${{ vars.TWINE_REPOSITORY }}
+                TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+                TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+              run: ./release $SEMVER_BUMP

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -19,6 +19,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
             - name: Setup Git
               run: |
                 git config --local user.email "action@github.com"

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
     release:
         name: Release
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
This is a WIP trying to address issue #220. I'll reiterate my summary of progress, functionality and unaddressed issues so far:

> This has a dropdown manual workflow trigger for "patch", "minor" and "major". It has a e.g. repo specified environment variable TWINE_REPOSITORY for pypi or testpypi (production or test). It has two e.g. repo secrets TWINE_USERNAME and TWINE_PASSWORD for pypi authentication.
> 
> I have successfully (after multiple failed attempts) ran this with on a slightly modified fork to get a test release and a error free workflow: https://test.pypi.org/project/ondkloss-github-backup/#description
> 
> The run: https://github.com/Ondkloss/python-github-backup/actions/runs/6535505694/job/17745125180
> 
> Issues and comments so far:
> 
> * Currently unsure/untested if I need to `setup-python`
> * It generates faulty(?) changelog. See e.g. the resulting `CHANGES.rst` from my testpypi release, which pretty much overwrote everything: https://github.com/Ondkloss/python-github-backup/blob/master/CHANGES.rst
> * I can't really say I'm understanding how this happens from the `gitchangelog` call
> * I see a `docs/conf.py` section in `release` that I don't know what is and if I have to handle it somehow
> * There's no particular thought to the choice of Ubuntu 20.04
> * Pypi warns that username/password will require 2FA soon. Unsure how to handle another form of authentication using twine