### PR TITLE
Add options to include certain number of latest release and skip prereleases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,8 @@ CLI Help output::
                   [-P] [-F] [--prefer-ssh] [-v]
                   [--keychain-name OSX_KEYCHAIN_ITEM_NAME]
                   [--keychain-account OSX_KEYCHAIN_ITEM_ACCOUNT]
-                  [--releases] [--assets] [--exclude [REPOSITORY [REPOSITORY ...]]
+                  [--releases] [--assets] [--latest-releases INCLUDE_LATEST_RELEASES]
+                  [--exclude [REPOSITORY [REPOSITORY ...]]
                   [--throttle-limit THROTTLE_LIMIT] [--throttle-pause THROTTLE_PAUSE]
                   USER
 
@@ -125,6 +126,9 @@ CLI Help output::
       --releases            include release information, not including assets or
                             binaries
       --assets              include assets alongside release information; only
+                            applies if including releases
+      --latest-releases INCLUDE_LATEST_RELEASES
+                            include certain number of the latest releases; only
                             applies if including releases
       --exclude [REPOSITORY [REPOSITORY ...]]
                             names of repositories to exclude from backup.

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,8 @@ CLI Help output::
                   [-P] [-F] [--prefer-ssh] [-v]
                   [--keychain-name OSX_KEYCHAIN_ITEM_NAME]
                   [--keychain-account OSX_KEYCHAIN_ITEM_ACCOUNT]
-                  [--releases] [--assets] [--latest-releases INCLUDE_LATEST_RELEASES]
+                  [--releases] [--latest-releases NUMBER_OF_LATEST_RELEASES]
+                  [--skip-prerelease] [--assets]
                   [--exclude [REPOSITORY [REPOSITORY ...]]
                   [--throttle-limit THROTTLE_LIMIT] [--throttle-pause THROTTLE_PAUSE]
                   USER
@@ -125,7 +126,7 @@ CLI Help output::
                             keychain that holds the personal access or OAuth token
       --releases            include release information, not including assets or
                             binaries
-      --latest-releases INCLUDE_LATEST_RELEASES
+      --latest-releases NUMBER_OF_LATEST_RELEASES
                             include certain number of the latest releases;
                             only applies if including releases
       --skip-prerelease     skip prerelease and draft versions; only applies if including releases

--- a/README.rst
+++ b/README.rst
@@ -125,10 +125,11 @@ CLI Help output::
                             keychain that holds the personal access or OAuth token
       --releases            include release information, not including assets or
                             binaries
-      --assets              include assets alongside release information; only
-                            applies if including releases
       --latest-releases INCLUDE_LATEST_RELEASES
-                            include certain number of the latest releases; only
+                            include certain number of the latest releases;
+                            only applies if including releases
+      --skip-prerelease     skip prerelease and draft versions; only applies if including releases
+      --assets              include assets alongside release information; only
                             applies if including releases
       --exclude [REPOSITORY [REPOSITORY ...]]
                             names of repositories to exclude from backup.

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -511,7 +511,7 @@ def get_github_host(args):
 
 
 def read_file_contents(file_uri):
-    return open(file_uri[len(FILE_URI_PREFIX) :], "rt").readline().strip()
+    return open(file_uri[len(FILE_URI_PREFIX):], "rt").readline().strip()
 
 
 def get_github_repo_url(args, repository):
@@ -1221,10 +1221,10 @@ def backup_releases(args, repo_cwd, repository, repos_template, include_assets=F
     releases = retrieve_data(args, release_template, query_args=query_args)
 
     if args.skip_prerelease:
-        releases = [r for r in releases if r["prerelease"] == False and r["draft"] == False]
+        releases = [r for r in releases if not r["prerelease"] and not r["draft"]]
 
     if args.number_of_latest_releases and args.number_of_latest_releases < len(releases):
-        releases.sort(key=lambda item: datetime.strptime(item["created_at"], "%Y-%m-%dT%H:%M:%SZ"), \
+        releases.sort(key=lambda item: datetime.strptime(item["created_at"], "%Y-%m-%dT%H:%M:%SZ"),
                       reverse=True)
         releases = releases[:args.number_of_latest_releases]
         logger.info("Saving the latest {0} releases to disk".format(len(releases)))

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -381,7 +381,7 @@ def parse_args(args=None):
         "--latest-releases",
         type=int,
         default=0,
-        dest="include_latest_releases",
+        dest="number_of_latest_releases",
         help="include certain number of the latest releases; only applies if including releases",
     )
     parser.add_argument(
@@ -1223,10 +1223,10 @@ def backup_releases(args, repo_cwd, repository, repos_template, include_assets=F
     if args.skip_prerelease:
         releases = [r for r in releases if r["prerelease"] == False and r["draft"] == False]
 
-    if args.include_latest_releases and args.include_latest_releases < len(releases):
+    if args.number_of_latest_releases and args.number_of_latest_releases < len(releases):
         releases.sort(key=lambda item: datetime.strptime(item["created_at"], "%Y-%m-%dT%H:%M:%SZ"), \
                       reverse=True)
-        releases = releases[:args.include_latest_releases]
+        releases = releases[:args.number_of_latest_releases]
         logger.info("Saving the latest {0} releases to disk".format(len(releases)))
     else:
         logger.info("Saving {0} releases to disk".format(len(releases)))

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -23,7 +23,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote as urlquote
 from urllib.parse import urlencode, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
-from operator import itemgetter
+from datetime import datetime
 
 try:
     from . import __version__
@@ -378,17 +378,23 @@ def parse_args(args=None):
         help="include release information, not including assets or binaries",
     )
     parser.add_argument(
-        "--assets",
-        action="store_true",
-        dest="include_assets",
-        help="include assets alongside release information; only applies if including releases",
-    )
-    parser.add_argument(
         "--latest-releases",
         type=int,
         default=0,
         dest="include_latest_releases",
         help="include certain number of the latest releases; only applies if including releases",
+    )
+    parser.add_argument(
+        "--skip-prerelease",
+        action="store_true",
+        dest="skip_prerelease",
+        help="skip prerelease and draft versions; only applies if including releases",
+    )
+    parser.add_argument(
+        "--assets",
+        action="store_true",
+        dest="include_assets",
+        help="include assets alongside release information; only applies if including releases",
     )
     parser.add_argument(
         "--throttle-limit",
@@ -1214,8 +1220,12 @@ def backup_releases(args, repo_cwd, repository, repos_template, include_assets=F
     release_template = "{0}/{1}/releases".format(repos_template, repository_fullname)
     releases = retrieve_data(args, release_template, query_args=query_args)
 
+    if args.skip_prerelease:
+        releases = [r for r in releases if r["prerelease"] == False and r["draft"] == False]
+
     if args.include_latest_releases and args.include_latest_releases < len(releases):
-        releases = sorted(releases, key=itemgetter('tag_name'), reverse=True)
+        releases.sort(key=lambda item: datetime.strptime(item["created_at"], "%Y-%m-%dT%H:%M:%SZ"), \
+                      reverse=True)
         releases = releases[:args.include_latest_releases]
         logger.info("Saving the latest {0} releases to disk".format(len(releases)))
     else:


### PR DESCRIPTION
Add two options:
- `--latest-releases NUMBER_OF_LATEST_RELEASES` &ndash; include certain number of the latest releases by creation date
- `--skip-prerelease` &ndash; skip prerelease and draft versions

They can help reduce backup time and disk space for repositories with a large number of releases and assets.