### PR TITLE
Fix 404 on hooks

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -1189,8 +1189,11 @@ def backup_hooks(args, repo_cwd, repository, repos_template):
     template = "{0}/{1}/hooks".format(repos_template, repository["full_name"])
     try:
         _backup_data(args, "hooks", template, output_file, hook_cwd)
-    except SystemExit:
-        logger.info("Unable to read hooks, skipping")
+    except Exception as e:
+        if "404" in str(e):
+            logger.info("Unable to read hooks, skipping")
+        else:
+            raise e
 
 
 def backup_releases(args, repo_cwd, repository, repos_template, include_assets=False):


### PR DESCRIPTION
Repositories where no webhooks are defined return 404 errors. This breaks further script execution.

Fixes #176