### PR TITLE
234 Backing up releases using fine grained token ends with an error

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -777,14 +777,19 @@ class S3HTTPRedirectHandler(HTTPRedirectHandler):
         return request
 
 
-def download_file(url, path, auth):
+def download_file(url, path, auth, as_app=False, fine=False):
     # Skip downloading release assets if they already exist on disk so we don't redownload on every sync
     if os.path.exists(path):
         return
 
-    request = Request(url)
+    request = _construct_request(per_page=100, 
+                                 page=1, 
+                                 query_args={}, 
+                                 template=url, 
+                                 auth=auth, 
+                                 as_app=as_app, 
+                                 fine=fine)
     request.add_header("Accept", "application/octet-stream")
-    request.add_header("Authorization", "Basic ".encode("ascii") + auth)
     opener = build_opener(S3HTTPRedirectHandler)
 
     try:
@@ -1255,6 +1260,8 @@ def backup_releases(args, repo_cwd, repository, repos_template, include_assets=F
                         asset["url"],
                         os.path.join(release_assets_cwd, asset["name"]),
                         get_auth(args),
+                        as_app=True if args.as_app is not None else False,
+                        fine=True if args.token_fine is not None else False
                     )
 
 

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -1260,7 +1260,7 @@ def backup_releases(args, repo_cwd, repository, repos_template, include_assets=F
                         asset["url"],
                         os.path.join(release_assets_cwd, asset["name"]),
                         get_auth(args),
-                        as_app=True if args.as_app is not None else False,
+                        as_app=args.as_app,
                         fine=True if args.token_fine is not None else False
                     )
 

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -782,12 +782,12 @@ def download_file(url, path, auth, as_app=False, fine=False):
     if os.path.exists(path):
         return
 
-    request = _construct_request(per_page=100, 
-                                 page=1, 
-                                 query_args={}, 
-                                 template=url, 
-                                 auth=auth, 
-                                 as_app=as_app, 
+    request = _construct_request(per_page=100,
+                                 page=1,
+                                 query_args={},
+                                 template=url,
+                                 auth=auth,
+                                 as_app=as_app,
                                  fine=fine)
     request.add_header("Accept", "application/octet-stream")
     opener = build_opener(S3HTTPRedirectHandler)


### PR DESCRIPTION
This PR addresses #234 

## Summary

- I change the request in `download_file` to be built by `_construct_request` as it handles authentication with fine grained tokens better
- I updated the `download_file` params to include optional `as_app` and optional `fine` so these arguments can be passed into `_construct_request`

## Problem

When downloading assets using a fine grained token you will get a "can't concat str to bytes" error. This is due to the fine grained token being concatenated onto bytes in the line:

`request.add_header("Authorization", "Basic ".encode("ascii") + auth)`

This is fixed by using the `_construct_request` function.