### PR TITLE
fix: do not double encode auth when retrieving release assets

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -1259,7 +1259,7 @@ def backup_releases(args, repo_cwd, repository, repos_template, include_assets=F
                     download_file(
                         asset["url"],
                         os.path.join(release_assets_cwd, asset["name"]),
-                        get_auth(args),
+                        get_auth(args, encode=not args.as_app),
                         as_app=args.as_app,
                         fine=True if args.token_fine is not None else False
                     )


### PR DESCRIPTION
Downloading release assets while using --as-app failed, due to auth string being encoded twice. Both in backup_releases() and again in _construct_request(). This caused the output "'bytes' object has no attribute 'encode'".

This PR modifies backup_releases() get_auth call to match retrieve_data_gen() get_auth which is used for most other calls. 

