### PR TITLE
git fetch is required even when using lfs

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -1318,13 +1318,15 @@ def fetch_repository(
             git_command = ["git", "remote", "set-url", "origin", remote_url]
             logging_subprocess(git_command, cwd=local_dir)
 
-        if lfs_clone:
-            git_command = ["git", "lfs", "fetch", "--all", "--prune"]
-        else:
-            git_command = ["git", "fetch", "--all", "--force", "--tags", "--prune"]
+        git_command = ["git", "fetch", "--all", "--force", "--tags", "--prune"]
         if no_prune:
             git_command.pop()
         logging_subprocess(git_command, cwd=local_dir)
+        if lfs_clone:
+            git_command = ["git", "lfs", "fetch", "--all", "--prune"]
+            if no_prune:
+                git_command.pop()
+            logging_subprocess(git_command, cwd=local_dir)
     else:
         logger.info(
             "Cloning {0} repository from {1} to {2}".format(


### PR DESCRIPTION
Command git fetch is required before git lfs fetch. Otherwise the latest commits are not fetched and only the LFS objects of the known commits are downloaded.
Basically, without this fix, when lfs option is enabled, the backups of the repositories are never updated and they only contain the commits present when the backup was performed the first time (i.e. at clone time).