### PR TITLE
Fix typo README.rst: --starred-gists that should be --gists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ Gotchas / Known-issues
 All is not everything
 ---------------------
 
-The ``--all`` argument does not include: cloning private repos (``-P, --private``), cloning forks (``-F, --fork``), cloning starred repositories (``--all-starred``), ``--pull-details``, cloning LFS repositories (``--lfs``), cloning gists (``--starred-gists``) or cloning starred gist repos (``--starred-gists``). See examples for more.
+The ``--all`` argument does not include: cloning private repos (``-P, --private``), cloning forks (``-F, --fork``), cloning starred repositories (``--all-starred``), ``--pull-details``, cloning LFS repositories (``--lfs``), cloning gists (``--gists``) or cloning starred gist repos (``--starred-gists``). See examples for more.
 
 Cloning all starred size
 ------------------------


### PR DESCRIPTION
The line modified by this commit previously mentioned `--starred-gists` twice, and I think the first mention should be `--gists`.

The line was `cloning gists (``--starred-gists``) or cloning starred gist repos (``--starred-gists``)`.
The line is now `cloning gists (``--gists``) or cloning starred gist repos (``--starred-gists``)`.
