### PR TITLE
Update required permissions listed in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ Customise the permissions for your use case, but for a personal account full bac
 
 **User permissions**: Read access to followers, starring, and watching.
 
-**Repository permissions**: Read access to code, commit statuses, issues, metadata, pages, pull requests, and repository hooks.
+**Repository permissions**: Read access to contents, issues, metadata, pull requests, and webhooks.
 
 
 Prefer SSH


### PR DESCRIPTION
Removed unused permissions, and changed names to those currently used by GitHub.

- code: renamed to contents as used by GitHub
- commit statuses: removed because not used by github-backup
- pages: removed because not used by github-backup
- repository hooks: renamed to webhooks as used by GitHub

For the "commit statuses" and "pages" permissions, I could not find any indication in the code that 
the "status", "statuses", "pages" endpoints are used.  See https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-commit-statuses and https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-pages.