### PR TITLE
Fix -R flag to allow backups of repositories not owned by user

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -4,15 +4,6 @@ import logging
 import os
 import sys
 
-
-# If we are running from a git-checkout, we can run against the development
-# tree without installing.
-if os.path.exists(os.path.join(os.path.dirname(__file__), "..", ".git")):
-    sys.path.insert(
-        0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    )
-
-
 from github_backup.github_backup import (
     backup_account,
     backup_repositories,


### PR DESCRIPTION
Previously, using -R flag would show zero issues/PRs for repositories not owned by the primary user due to incorrect pagination parameters being added to single repository API calls.

**Changes:**
- Remove pagination parameters for single repository requests
- Support owner/repo format in -R flag (e.g., -R owner/repo-name)  
- Skip filtering when specific repository is requested
- Fix URL construction for requests without query parameters

**Impact:**
This enables backing up any repository, not just those owned by the primary user specified in -u flag. Before this fix, attempting to backup repositories from other owners would result in zero issues/PRs being retrieved.