### PR TITLE
Skip DMCA'd repos which return a 451 response

### DIFF
--- a/tests/test_http_451.py
+++ b/tests/test_http_451.py
@@ -1,0 +1,143 @@
+"""Tests for HTTP 451 (DMCA takedown) handling."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from github_backup import github_backup
+
+
+class TestHTTP451Exception:
+    """Test suite for HTTP 451 DMCA takedown exception handling."""
+
+    def test_repository_unavailable_error_raised(self):
+        """HTTP 451 should raise RepositoryUnavailableError with DMCA URL."""
+        # Create mock args
+        args = Mock()
+        args.as_app = False
+        args.token_fine = None
+        args.token_classic = None
+        args.username = None
+        args.password = None
+        args.osx_keychain_item_name = None
+        args.osx_keychain_item_account = None
+        args.throttle_limit = None
+        args.throttle_pause = 0
+
+        # Mock HTTPError 451 response
+        mock_response = Mock()
+        mock_response.getcode.return_value = 451
+
+        dmca_data = {
+            "message": "Repository access blocked",
+            "block": {
+                "reason": "dmca",
+                "created_at": "2024-11-12T14:38:04Z",
+                "html_url": "https://github.com/github/dmca/blob/master/2024/11/2024-11-04-source-code.md"
+            }
+        }
+        mock_response.read.return_value = json.dumps(dmca_data).encode("utf-8")
+        mock_response.headers = {"x-ratelimit-remaining": "5000"}
+        mock_response.reason = "Unavailable For Legal Reasons"
+
+        def mock_get_response(request, auth, template):
+            return mock_response, []
+
+        with patch("github_backup.github_backup._get_response", side_effect=mock_get_response):
+            with pytest.raises(github_backup.RepositoryUnavailableError) as exc_info:
+                list(github_backup.retrieve_data_gen(args, "https://api.github.com/repos/test/dmca/issues"))
+
+            # Check exception has DMCA URL
+            assert exc_info.value.dmca_url == "https://github.com/github/dmca/blob/master/2024/11/2024-11-04-source-code.md"
+            assert "451" in str(exc_info.value)
+
+    def test_repository_unavailable_error_without_dmca_url(self):
+        """HTTP 451 without DMCA details should still raise exception."""
+        args = Mock()
+        args.as_app = False
+        args.token_fine = None
+        args.token_classic = None
+        args.username = None
+        args.password = None
+        args.osx_keychain_item_name = None
+        args.osx_keychain_item_account = None
+        args.throttle_limit = None
+        args.throttle_pause = 0
+
+        mock_response = Mock()
+        mock_response.getcode.return_value = 451
+        mock_response.read.return_value = b'{"message": "Blocked"}'
+        mock_response.headers = {"x-ratelimit-remaining": "5000"}
+        mock_response.reason = "Unavailable For Legal Reasons"
+
+        def mock_get_response(request, auth, template):
+            return mock_response, []
+
+        with patch("github_backup.github_backup._get_response", side_effect=mock_get_response):
+            with pytest.raises(github_backup.RepositoryUnavailableError) as exc_info:
+                list(github_backup.retrieve_data_gen(args, "https://api.github.com/repos/test/dmca/issues"))
+
+            # Exception raised even without DMCA URL
+            assert exc_info.value.dmca_url is None
+            assert "451" in str(exc_info.value)
+
+    def test_repository_unavailable_error_with_malformed_json(self):
+        """HTTP 451 with malformed JSON should still raise exception."""
+        args = Mock()
+        args.as_app = False
+        args.token_fine = None
+        args.token_classic = None
+        args.username = None
+        args.password = None
+        args.osx_keychain_item_name = None
+        args.osx_keychain_item_account = None
+        args.throttle_limit = None
+        args.throttle_pause = 0
+
+        mock_response = Mock()
+        mock_response.getcode.return_value = 451
+        mock_response.read.return_value = b"invalid json {"
+        mock_response.headers = {"x-ratelimit-remaining": "5000"}
+        mock_response.reason = "Unavailable For Legal Reasons"
+
+        def mock_get_response(request, auth, template):
+            return mock_response, []
+
+        with patch("github_backup.github_backup._get_response", side_effect=mock_get_response):
+            with pytest.raises(github_backup.RepositoryUnavailableError):
+                list(github_backup.retrieve_data_gen(args, "https://api.github.com/repos/test/dmca/issues"))
+
+    def test_other_http_errors_unchanged(self):
+        """Other HTTP errors should still raise generic Exception."""
+        args = Mock()
+        args.as_app = False
+        args.token_fine = None
+        args.token_classic = None
+        args.username = None
+        args.password = None
+        args.osx_keychain_item_name = None
+        args.osx_keychain_item_account = None
+        args.throttle_limit = None
+        args.throttle_pause = 0
+
+        mock_response = Mock()
+        mock_response.getcode.return_value = 404
+        mock_response.read.return_value = b'{"message": "Not Found"}'
+        mock_response.headers = {"x-ratelimit-remaining": "5000"}
+        mock_response.reason = "Not Found"
+
+        def mock_get_response(request, auth, template):
+            return mock_response, []
+
+        with patch("github_backup.github_backup._get_response", side_effect=mock_get_response):
+            # Should raise generic Exception, not RepositoryUnavailableError
+            with pytest.raises(Exception) as exc_info:
+                list(github_backup.retrieve_data_gen(args, "https://api.github.com/repos/test/notfound/issues"))
+
+            assert not isinstance(exc_info.value, github_backup.RepositoryUnavailableError)
+            assert "404" in str(exc_info.value)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #163 - Handle HTTP 451 (DMCA takedown) responses 

When encountering a 451 due to DMCA'd repositories, log a warning with the DMCA notice URL and continue with other repositories, instead of terminating with the error.

To avoid multiple messages and repeated wasted requests for each component (eg issues, prs) the tool raises an exception so multiple activities for the repo can be skipped to move onto the next one.

Example of skipping DMCA'd repo `127MU/phigros-html5`

```bash
github-backup 127MU -t TOKEN --output-directory /private/tmp/test_dmca_v2 --issues --pulls --milestones --labels --releases --fork
```

```
2025-11-29T09:10:57.332: Create output directory /private/tmp/test_dmca_v2
2025-11-29T09:10:57.332: Backing up user 127MU to /private/tmp/test_dmca_v2
2025-11-29T09:10:57.844: Retrieving repositories
2025-11-29T09:10:58.271: Backing up repositories

2025-11-29T09:10:58.271: Retrieving 127MU/127MU issues
...
2025-11-29T09:10:59.153: Saving 0 issues to disk

2025-11-29T09:10:59.931: Retrieving 127MU/Mining issues
...
2025-11-29T09:11:01.111: Saving 0 releases to disk

2025-11-29T09:11:01.111: Retrieving 127MU/Mining issues
2025-11-29T09:11:01.112: Requesting https://api.github.com/repos/127MU/Mining/issues?per_page=100&filter=all&state=open
...
2025-11-29T09:11:03.950: Saving 0 releases to disk

2025-11-29T09:11:03.951: Retrieving 127MU/phigros-html5 issues
2025-11-29T09:11:03.951: Requesting https://api.github.com/repos/127MU/phigros-html5/issues?per_page=100&filter=all&state=open
2025-11-29T09:11:04.324: Repository 127MU/phigros-html5 is unavailable (HTTP 451)
2025-11-29T09:11:04.324: DMCA notice: https://github.com/github/dmca/blob/master/2024/11/2024-11-04-source-code.md
2025-11-29T09:11:04.324: Skipping remaining resources for 127MU/phigros-html5

2025-11-29T09:11:04.324: Retrieving 127MU/RIP-PrivateMod issues
...
2025-11-29T09:11:07.533: Saving 0 releases to disk

2025-11-29T09:11:07.533: Retrieving 127MU/YunzaiBotHelper issues
...
2025-11-29T09:11:10.353: Saving 0 releases to disk
```

Exit code is 0. 

Added pytest on the 451 logic (written by AI).

**Side note**

DMCA'd repositories will have an empty directory created (e.g., `repositories/phigros-html5/issues/`). This occurs because directory creation happens before the first API request. It would be a bigger refactor to change the order of when the directory is created. Considered writing an UNAVAILABLE.txt to the directory, but that gets messy as a repo can be un-DMA'd (e.g. youtube-dl) and a subsequent run might work and populate the directories.
