### PR TITLE
fix: case-sensitive username filtering causing silent backup failures

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -1587,7 +1587,9 @@ def filter_repositories(args, unfiltered_repositories):
     repositories = []
     for r in unfiltered_repositories:
         # gists can be anonymous, so need to safely check owner
-        if r.get("owner", {}).get("login") == args.user or r.get("is_starred"):
+        # Use case-insensitive comparison to match GitHub's case-insensitive username behavior
+        owner_login = r.get("owner", {}).get("login", "")
+        if owner_login.lower() == args.user.lower() or r.get("is_starred"):
             repositories.append(r)
 
     name_regex = None


### PR DESCRIPTION
Fixes #198 - Fix case-sensitive username filtering

GitHub's API accepts usernames in any case (e.g., `prai-org`, `PRAI-Org`, `PrAi-OrG`) but always returns the canonical case in the response. When you type a username with different casing than GitHub's canonical form, the tool's case-sensitive string comparison causes all repositories to be filtered out.

**How to reproduce:**

The tool calls `/user/repos` which returns all repos the authenticated user has access to. GitHub accepts any case in the command line argument but returns the canonical case in the response:

```bash
curl -s -H "Authorization: token $TOKEN" https://api.github.com/user/repos | jq '.[0]'

# Returns repos with canonical case in owner.login:
{
  "name": "AdventOfCode",
  "owner": {
    "login": "Iamrodos"  // Capital I - canonical case from GitHub
  }
}
```

As the filer compares "Iamrodos" == "iamrodos" the result is false.

**The bug:**

At `github_backup/github_backup.py:1590`, the code does exact string matching:

```python
if r.get("owner", {}).get("login") == args.user or r.get("is_starred"):
```

Since GitHub's API is not case-sensitive for usernames, the tool's filter shouldn't be either.

**History:**

This bug was introduced in commit [d362adb](https://github.com/josegonzalez/python-github-backup/commit/d362adbbca0f6d4d2cd70a239f9263c1654a13fc) (January 2016) when the tool switched from `/users/{user}/repos` to `/user/repos` for private repository access. The `/user/repos` endpoint returns all repos the authenticated user can see (including organization repos), requiring filtering by owner. The filter comparison was inadvertently made case-sensitive.

**Fix:**

Changed the comparison to be case-insensitive:

```python
owner_login = r.get("owner", {}).get("login", "")
if owner_login.lower() == args.user.lower() or r.get("is_starred"):
```

Tested with multiple repos using lowercase, uppercase, and mixed case usernames.
