### PR TITLE
fix: warn and skip when --starred-gists used for different user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -301,6 +301,8 @@ Starred gists vs starred repo behaviour
 
 The starred normal repo cloning (``--all-starred``) argument stores starred repos separately to the users own repositories. However, using ``--starred-gists`` will store starred gists within the same directory as the users own gists ``--gists``. Also, all gist repo directory names are IDs not the gist's name.
 
+Note: ``--starred-gists`` only retrieves starred gists for the authenticated user, not the target user, due to a GitHub API limitation.
+
 
 Skip existing on incomplete backups
 -----------------------------------

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -1565,16 +1565,22 @@ def retrieve_repositories(args, authenticated_user):
         repos.extend(gists)
 
     if args.include_starred_gists:
-        starred_gists_template = "https://{0}/gists/starred".format(
-            get_github_api_host(args)
-        )
-        starred_gists = retrieve_data(
-            args, starred_gists_template, single_request=False
-        )
-        # flag each repo as a starred gist for downstream processing
-        for item in starred_gists:
-            item.update({"is_gist": True, "is_starred": True})
-        repos.extend(starred_gists)
+        if not authenticated_user.get("login") or args.user.lower() != authenticated_user["login"].lower():
+            logger.warning(
+                "Cannot retrieve starred gists for '%s'. GitHub only allows access to the authenticated user's starred gists.",
+                args.user,
+            )
+        else:
+            starred_gists_template = "https://{0}/gists/starred".format(
+                get_github_api_host(args)
+            )
+            starred_gists = retrieve_data(
+                args, starred_gists_template, single_request=False
+            )
+            # flag each repo as a starred gist for downstream processing
+            for item in starred_gists:
+                item.update({"is_gist": True, "is_starred": True})
+            repos.extend(starred_gists)
 
     return repos
 


### PR DESCRIPTION
GitHub's API only allows retrieving starred gists for the authenticated user. Previously, using --starred-gists when backing up a different user would silently return no relevant data.

Now warns and skips the retrieval entirely when the target user differs from the authenticated user. Uses case-insensitive comparison to match GitHub's username handling.

Fixes #93