### PR TITLE
fix: replace deprecated git lfs clone with git clone + git lfs fetch --all

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,8 @@ When you use the ``--lfs`` option, you will need to make sure you have Git LFS i
 
 Instructions on how to do this can be found on https://git-lfs.github.com.
 
+LFS objects are fetched for all refs, not just the current checkout, ensuring a complete backup of all LFS content across all branches and history.
+
 
 About Attachments
 -----------------

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -2090,11 +2090,13 @@ def fetch_repository(
                     git_command.pop()
                 logging_subprocess(git_command, cwd=local_dir)
         else:
-            if lfs_clone:
-                git_command = ["git", "lfs", "clone", remote_url, local_dir]
-            else:
-                git_command = ["git", "clone", remote_url, local_dir]
+            git_command = ["git", "clone", remote_url, local_dir]
             logging_subprocess(git_command)
+            if lfs_clone:
+                git_command = ["git", "lfs", "fetch", "--all", "--prune"]
+                if no_prune:
+                    git_command.pop()
+                logging_subprocess(git_command, cwd=local_dir)
 
 
 def backup_account(args, output_directory):


### PR DESCRIPTION
The `git lfs clone` command is deprecated. Modern git clone handles LFS automatically.

This change replaces `git lfs clone` with `git clone` followed by `git lfs fetch --all`, which ensures all LFS objects across all refs are backed up. This matches the existing bare clone behavior and provides complete LFS backups.

Closes #379
