### PR TITLE
docs: Add missing `--retries` argument to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ CLI Help output::
                   [--skip-assets-on [SKIP_ASSETS_ON ...]] [--attachments]
                   [--throttle-limit THROTTLE_LIMIT]
                   [--throttle-pause THROTTLE_PAUSE]
-                  [--exclude [EXCLUDE ...]]
+                  [--exclude [EXCLUDE ...]] [--retries MAX_RETRIES]
                   USER
 
     Backup a github account


### PR DESCRIPTION
The argument was already listed in the detailed options list below, but was missing in the options summary.