### PR TITLE
Fix subprocess deadlock hanging backups on Windows (#519)

### DIFF
--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -12,11 +12,11 @@ import os
 import platform
 import random
 import re
-import select
 import socket
 import ssl
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Generator
 from datetime import datetime
@@ -91,31 +91,36 @@ def logging_subprocess(
     child = subprocess.Popen(
         popenargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs
     )
-    if sys.platform == "win32":
-        logger.info(
-            "Windows operating system detected - no subprocess logging will be returned"
-        )
 
-    log_level = {child.stdout: stdout_log_level, child.stderr: stderr_log_level}
+    def log_output(pipe, log_level):
+        # Drain the pipe from a thread so the child never blocks on a full
+        # pipe buffer (issue #519), logging each line as it arrives.
+        with pipe:
+            for line in iter(pipe.readline, b""):
+                try:
+                    logger.log(log_level, line.rstrip(b"\r\n"))
+                except Exception:
+                    # Keep draining even if logging fails, or the child
+                    # blocks on a full pipe buffer again
+                    pass
 
-    def check_io():
-        if sys.platform == "win32":
-            return
-        ready_to_read = select.select([child.stdout, child.stderr], [], [], 1000)[0]
-        for io in ready_to_read:
-            line = io.readline()
-            if not logger:
-                continue
-            if not (io == child.stderr and not line):
-                logger.log(log_level[io], line[:-1])
-
-    # keep checking stdout/stderr until the child exits
-    while child.poll() is None:
-        check_io()
-
-    check_io()  # check again to catch anything after the process exits
+    threads = [
+        threading.Thread(
+            target=log_output, args=(child.stdout, stdout_log_level), daemon=True
+        ),
+        threading.Thread(
+            target=log_output, args=(child.stderr, stderr_log_level), daemon=True
+        ),
+    ]
+    for thread in threads:
+        thread.start()
 
     rc = child.wait()
+
+    # Timeout in case a grandchild inherited the pipe handles and keeps
+    # them open past the child's exit, which would delay EOF indefinitely
+    for thread in threads:
+        thread.join(timeout=60)
 
     if rc != 0:
         print("{} returned {}:".format(popenargs[0], rc), file=sys.stderr)

--- a/tests/test_logging_subprocess.py
+++ b/tests/test_logging_subprocess.py
@@ -1,0 +1,113 @@
+"""Tests for logging_subprocess pipe handling (issue #519)."""
+
+import logging
+import sys
+import threading
+
+import pytest
+
+from github_backup import github_backup
+
+
+class TestLoggingSubprocess:
+    """Test suite for logging_subprocess deadlock and logging behavior."""
+
+    def test_large_stderr_output_does_not_deadlock(self):
+        """Child output larger than the OS pipe buffer must not hang.
+
+        Regression test for issue #519: on Windows the pipes were never
+        drained, so the child blocked once its output exceeded the pipe
+        buffer (~8KB) and the parent spun forever on poll().
+        """
+        # Write 256KB to stderr, far past any platform's pipe buffer
+        child_code = (
+            "import sys\n"
+            "for _ in range(3200):\n"
+            "    sys.stderr.write('x' * 79 + '\\n')\n"
+        )
+        result = {}
+
+        def run():
+            result["rc"] = github_backup.logging_subprocess(
+                [sys.executable, "-c", child_code]
+            )
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join(timeout=30)
+
+        assert not thread.is_alive(), "logging_subprocess deadlocked on large output"
+        assert result["rc"] == 0
+
+    def test_stdout_logged_at_debug_stderr_at_error(self, caplog):
+        """stdout lines log at DEBUG and stderr lines at ERROR."""
+        child_code = (
+            "import sys\n"
+            "print('to stdout')\n"
+            "print('to stderr', file=sys.stderr)\n"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="github_backup.github_backup"):
+            rc = github_backup.logging_subprocess([sys.executable, "-c", child_code])
+
+        assert rc == 0
+        records = [
+            (r.levelno, r.getMessage())
+            for r in caplog.records
+            if r.name == "github_backup.github_backup"
+        ]
+        assert (logging.DEBUG, str(b"to stdout")) in records
+        assert (logging.ERROR, str(b"to stderr")) in records
+
+    def test_trailing_newlines_stripped(self, caplog):
+        """Logged lines have trailing \\r\\n stripped, including Windows CRLF."""
+        child_code = (
+            "import sys\n"
+            "sys.stdout.buffer.write(b'crlf line\\r\\n')\n"
+            "sys.stdout.buffer.write(b'lf line\\n')\n"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="github_backup.github_backup"):
+            rc = github_backup.logging_subprocess([sys.executable, "-c", child_code])
+
+        assert rc == 0
+        messages = [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "github_backup.github_backup"
+        ]
+        assert str(b"crlf line") in messages
+        assert str(b"lf line") in messages
+
+    def test_final_line_without_newline_not_truncated(self, caplog):
+        """A final line with no trailing newline keeps its last character.
+
+        The old code stripped the newline with line[:-1], which chopped the
+        last character off any line that did not end with a newline.
+        """
+        child_code = "import sys\nsys.stdout.write('no newline')\n"
+
+        with caplog.at_level(logging.DEBUG, logger="github_backup.github_backup"):
+            rc = github_backup.logging_subprocess([sys.executable, "-c", child_code])
+
+        assert rc == 0
+        messages = [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "github_backup.github_backup"
+        ]
+        assert str(b"no newline") in messages
+
+    def test_returns_child_exit_code(self, capsys):
+        """Non-zero child exit codes are returned and summarized on stderr."""
+        rc = github_backup.logging_subprocess(
+            [sys.executable, "-c", "import sys; sys.exit(3)"]
+        )
+
+        assert rc == 3
+        captured = capsys.readouterr()
+        assert "returned 3" in captured.err
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #519.

On Windows, `logging_subprocess` created child processes with piped stdout/stderr but never drained them — `check_io()` returned immediately on `win32` (since `select()` only supports sockets there, not pipes). Once a git operation wrote more than the OS pipe buffer (~8KB in my testing), the child blocked on a full pipe and the parent spun forever on `child.poll()`, hanging the entire backup. In practice any non-trivial `git clone`/`fetch` with progress output triggers it, so backups on Windows hang at the first sizeable repository. Quiet operations (e.g. an up-to-date incremental fetch) can slip under the buffer, which makes the bug look intermittent.

This replaces the `select()` loop with two reader threads that drain stdout/stderr and log each line as it arrives — the same design CPython's own `subprocess` module uses for `communicate()` on Windows. It works identically on all platforms, so the `win32` special-case (and its "no subprocess logging will be returned" limitation) is removed — Windows users now get subprocess logging too.

## Background

The regression dates to v0.44.0 (`7437e3a`, Oct 2023), which added the `win32` early-return to `check_io()` to stop `select()` crashing on Windows. That fixed the crash but left the pipes undrained, converting it into a hang. The underlying `select()` loop dates to v0.29.0 (`03c6856`) and never worked on Windows — so there's no prior release to revert to; a different draining mechanism was needed.

## Details

- Reader threads are daemons and joined with a timeout, so a grandchild that inherits the pipe handles (e.g. a long-lived git helper) can't stall the parent after the child exits
- The read loop keeps draining even if `logger.log()` raises, so a logging failure can't recreate the deadlock
- `rstrip(b"\r\n")` replaces `line[:-1]`, which left a stray `\r` on Windows CRLF output and chopped the last character off a final line with no trailing newline
- The `while child.poll() is None` busy-wait is gone — it pinned a CPU core on Windows for the duration of every git operation
- `select` import removed, `threading` added — stdlib only
- Log messages remain raw bytes (`b'...'`), exactly as the POSIX path logged before; decoding to str would be a user-visible format change better done as a follow-up

## Testing

- New `tests/test_logging_subprocess.py` (5 tests): a deadlock regression test (256KB of stderr, ~30x past the Windows pipe buffer, with a timeout guard so a regression fails CI instead of hanging it), log-level routing (stdout→DEBUG, stderr→ERROR), CRLF stripping, no-trailing-newline preservation, and exit-code passthrough
- Reproduced the hang on Windows 11 / Python 3.12: before the fix it deadlocked at just 8KB of child stderr; after, 1MB drains in ~0.3s
- Verified a real `git clone --progress` through `logging_subprocess` on Windows completes with full progress output logged
- Full suite: 132 passed; flake8 clean (`--ignore=E501,E203,W503`); changed region black-clean