### PR TITLE
Fix template URL for watched repositories backup

### DIFF
--- a/github_backup/cli.py
+++ b/github_backup/cli.py
@@ -81,7 +81,7 @@ def main():
     repositories = retrieve_repositories(args, authenticated_user)
     repositories = filter_repositories(args, repositories)
     backup_repositories(args, output_directory, repositories)
-    backup_account(args, output_directory)
+    backup_account(args, output_directory, authenticated_user)
 
 
 if __name__ == "__main__":

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -3075,7 +3075,7 @@ def backup_account(args, output_directory):
 
     if args.include_watched or args.include_everything:
         output_file = "{0}/watched.json".format(account_cwd)
-        template = "https://{0}/users/{1}/subscriptions".format(
+        template = "https://{0}/user/subscriptions".format(
             get_github_api_host(args), args.user
         )
         _backup_data(args, "watched repositories", template, output_file, account_cwd)

--- a/github_backup/github_backup.py
+++ b/github_backup/github_backup.py
@@ -3063,8 +3063,10 @@ def fetch_repository(
                 logging_subprocess(git_command, cwd=local_dir)
 
 
-def backup_account(args, output_directory):
+def backup_account(args, output_directory, authenticated_user=None):
     account_cwd = os.path.join(output_directory, "account")
+    if authenticated_user is None:
+        authenticated_user = {"login": None}
 
     if args.include_starred or args.include_everything:
         output_file = "{0}/starred.json".format(account_cwd)
@@ -3074,11 +3076,25 @@ def backup_account(args, output_directory):
         _backup_data(args, "starred repositories", template, output_file, account_cwd)
 
     if args.include_watched or args.include_everything:
-        output_file = "{0}/watched.json".format(account_cwd)
-        template = "https://{0}/user/subscriptions".format(
-            get_github_api_host(args), args.user
-        )
-        _backup_data(args, "watched repositories", template, output_file, account_cwd)
+        # GitHub deprecated /users/{username}/subscriptions; watched
+        # repositories are only available for the authenticated user via
+        # /user/subscriptions.
+        if (
+            not authenticated_user.get("login")
+            or args.user.lower() != authenticated_user["login"].lower()
+        ):
+            logger.warning(
+                "Cannot retrieve watched repositories for '%s'. GitHub only allows access to the authenticated user's watched repositories.",
+                args.user,
+            )
+        else:
+            output_file = "{0}/watched.json".format(account_cwd)
+            template = "https://{0}/user/subscriptions".format(
+                get_github_api_host(args)
+            )
+            _backup_data(
+                args, "watched repositories", template, output_file, account_cwd
+            )
 
     if args.include_followers or args.include_everything:
         output_file = "{0}/followers.json".format(account_cwd)


### PR DESCRIPTION
## Summary: github-backup --watched currently fails for personal account backups because GitHub has started returning empty responses from:

`GET /users/{username}/subscriptions`

This is now expected behavior per GitHub’s June 30, 2026 changelog:
  - https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/

GitHub states that /users/{username}/subscriptions is being deprecated and that, during the deprecation period, it may return empty responses or 403 Forbidden.

## Reproduction

```
github-backup PeterGabaldon\
  --output-directory /tmp/github-backup-test \
  --log-level info \
  --incremental \
  --token <REDACTED_PAT> \
  --watched
```

Current result:

> Requesting https://api.github.com/users/PeterGabaldon/subscriptions?per_page=100
> 
> Exception: Unexpected HTTP 204 from https://api.github.com/users/PeterGabaldon/subscriptions
> (expected non-2xx to raise HTTPError)

The token is valid and includes the relevant permissions. The same token works with the authenticated-user endpoint:

```
curl -i \
  -H "Authorization: Bearer <REDACTED_PAT>" \
  -H "Accept: application/vnd.github+json" \
  "https://api.github.com/user/subscriptions?per_page=100"
```

That returns 200 OK with the watched repository JSON array.

## Root Cause

--watched uses:

`/users/{username}/subscriptions`

That endpoint is no longer reliable for retrieving watched repositories, even when {username} is the authenticated user.

For backing up the authenticated user’s own watched repositories, GitHub now expects:

`/user/subscriptions`

## Fix

Changed endpoint